### PR TITLE
Fix segmentation position calculation for Allegro ECal.

### DIFF
--- a/detectorSegmentations/include/detectorSegmentations/FCCSWGridModuleThetaMerged_k4geo.h
+++ b/detectorSegmentations/include/detectorSegmentations/FCCSWGridModuleThetaMerged_k4geo.h
@@ -3,6 +3,7 @@
 
 // FCCSW
 #include "detectorSegmentations/GridTheta_k4geo.h"
+#include <atomic>
 
 /** FCCSWGridModuleThetaMerged_k4geo Detector/DetSegmentation/DetSegmentation/FCCSWGridModuleThetaMerged_k4geo.h FCCSWGridModuleThetaMerged_k4geo.h
  *
@@ -21,7 +22,7 @@ public:
   FCCSWGridModuleThetaMerged_k4geo(const BitFieldCoder* decoder);
 
   /// destructor
-  virtual ~FCCSWGridModuleThetaMerged_k4geo() = default;
+  virtual ~FCCSWGridModuleThetaMerged_k4geo();
 
   /// read n(modules) from detector metadata
   void GetNModulesFromGeom();
@@ -94,6 +95,20 @@ public:
    */
   inline const std::string& fieldNameModule() const { return m_moduleID; }
 
+  /// Extract the layer index fom a cell ID.
+  int layer(const CellID& aCellID) const;
+
+  /// Determine the volume ID from the full cell ID by removing all local fields
+  virtual VolumeID volumeID(const CellID& cellID) const;
+
+  /// Return true if this segmentation can have cells that span multiple
+  /// volumes.  That is, points from multiple distinct volumes may
+  /// be assigned to the same cell.
+  virtual bool cellsSpanVolumes() const
+  {
+    return true;
+  }
+
 protected:
   /// the field name used for layer
   std::string m_layerID;
@@ -110,6 +125,24 @@ protected:
   /// number of layers (from the geometry)
   int m_nLayers;
   
+private:
+  /// Tabulate the cylindrical radii of all layers, as well as the
+  /// local x and z components needed for the proper phi offset.
+  struct LayerInfo {
+    LayerInfo(double the_rho, double the_xloc, double the_zloc)
+      : rho(the_rho), xloc(the_xloc), zloc(the_zloc)
+    {}
+    double rho;
+    double xloc;
+    double zloc;
+  };
+  std::vector<LayerInfo> initLayerInfo(const CellID& cID) const;
+
+  // The vector of tabulated values, indexed by layer number.
+  // We can't build this in the constructor --- the volumes won't have
+  // been created yet.  Instead, build it lazily the first time it's needed.
+  // Since that's in a const method, make it thread-safe.
+  mutable std::atomic<const std::vector<LayerInfo>*> m_layerInfo = nullptr;
 };
 }
 }


### PR DESCRIPTION
Fix the calculation of cell position for FCCSWGridModuleThetaMerged_k4geo. Also add a layer() method to that class to extract the layer from a cell ID.



BEGINRELEASENOTES
- Thank you for writing the text to appear in the release notes. It will show up
  exactly as it appears between the two bold lines
- ...

ENDRELEASENOTES